### PR TITLE
document.c: fix trigger of -Werror=misleading-indentation

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1154,13 +1154,13 @@ char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offse
 		while (i < size) {
 			if (data[i] == '\\') i += 2;
 			else if (data[i] == '(' && i != 0) {
-				nb_p++; i++;
+				nb_p++;
 			}
 			else if (data[i] == ')') {
 				if (nb_p == 0) break;
-				else nb_p--; i++;
+				else nb_p--;
 			} else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
-			else i++;
+			i++;
 		}
 
 		if (i >= size) goto cleanup;


### PR DESCRIPTION
gcc 6.1.1 triggers a warning here, which breaks git rust build.
There is no actual bug, because the "if" branch exits the loop, but if it wasn't so, it'd be a bug.

```
/tmp/makepkg/build/rust-git/src/rust/src/rt/hoedown/src/document.c: In function 'char_link':
/tmp/makepkg/build/rust-git/src/rust/src/rt/hoedown/src/document.c:1161:5: error: this 'else' clause does not guard... [-Werror=misleading-indentation]
     else nb_p--; i++;
     ^~~~
/tmp/makepkg/build/rust-git/src/rust/src/rt/hoedown/src/document.c:1161:18: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'else'
     else nb_p--; i++;
```
