### PR TITLE
Fix GCC 6 misleading indentation warning

### DIFF
--- a/src/document.c
+++ b/src/document.c
@@ -1158,7 +1158,8 @@ char_link(hoedown_buffer *ob, hoedown_document *doc, uint8_t *data, size_t offse
 			}
 			else if (data[i] == ')') {
 				if (nb_p == 0) break;
-				else nb_p--; i++;
+				else nb_p--;
+				i++;
 			} else if (i >= 1 && _isspace(data[i-1]) && (data[i] == '\'' || data[i] == '"')) break;
 			else i++;
 		}


### PR DESCRIPTION
Clean up some misleading indentation which GCC 6 complains about.
